### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/davidhesse/2fbcd90c-c0aa-4948-b3dc-ac836ab089de/63c4eaf4-342e-4c83-8b6c-487570da7bda/_apis/work/boardbadge/9599c7e3-1f59-408a-8b8f-6ed7a6189604)](https://dev.azure.com/davidhesse/2fbcd90c-c0aa-4948-b3dc-ac836ab089de/_boards/board/t/63c4eaf4-342e-4c83-8b6c-487570da7bda/Microsoft.RequirementCategory)
 ## Welcome to GitHub Pages
 
 You can use the [editor on GitHub](https://github.com/DaRealHess/powercli-repo/edit/master/README.md) to maintain and preview the content for your website in Markdown files.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/davidhesse/2fbcd90c-c0aa-4948-b3dc-ac836ab089de/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.